### PR TITLE
Add server-side conveyor belt movement to V3 client players

### DIFF
--- a/gameserver/src/main/java/brainwine/gameserver/entity/Entity.java
+++ b/gameserver/src/main/java/brainwine/gameserver/entity/Entity.java
@@ -14,7 +14,9 @@ import brainwine.gameserver.player.Player;
 import brainwine.gameserver.server.Message;
 import brainwine.gameserver.server.messages.EffectMessage;
 import brainwine.gameserver.server.messages.EntityChangeMessage;
+import brainwine.gameserver.server.messages.EntityPositionMessage;
 import brainwine.gameserver.server.messages.EntityStatusMessage;
+import brainwine.gameserver.server.messages.PlayerPositionMessage;
 import brainwine.gameserver.util.MapHelper;
 import brainwine.gameserver.util.MathUtils;
 import brainwine.gameserver.zone.Block;
@@ -61,6 +63,12 @@ public abstract class Entity {
     public void tick(float deltaTime) {
         long now = System.currentTimeMillis();
         
+        // Do mechanical movement if necessary.
+        // Only for V3 clients (cocos2d client handles these client side)
+        if (isPlayer() && ((Player) this).isV3() && !((Player) this).isGodMode()) {
+            doMechanicalMovement(deltaTime);
+        }
+
         // Update block position
         updateBlockPosition();
         
@@ -164,6 +172,56 @@ public abstract class Entity {
             if(item.hasUse(ItemUseType.TRIGGER)) {
                 ItemUseType.SWITCH.getInteraction().interact(zone, this, blockX, blockY, Layer.FRONT, item, mod, metaBlock, null, null);
             }
+        }
+    }
+
+    /**
+     * Adjust entity position and velocity according to game mechanics, like items
+     * with a MOVE use.
+     *
+     * @param deltaTime change in time since last server tick in seconds
+     */
+    public void doMechanicalMovement(float deltaTime) {
+        float deltaVelocityX = 0.0f;
+        float deltaVelocityY = 0.0f;
+
+        float groundHeight = -1.0f;
+        boolean hasDistance = false;
+
+        Block block = zone.findBlock(blockX, blockY + 1, Layer.FRONT, item -> item.hasUse(ItemUseType.MOVE));
+        if (block == null && getY() - Math.floor(getY()) > 0.4) {
+            block = zone.findBlock(blockX, blockY + 2, Layer.FRONT, item -> item.hasUse(ItemUseType.MOVE));
+            hasDistance = true;
+        } 
+
+        if (block != null) {
+            Item frontItem = block.getFrontItem();
+
+            // item is assumed to be a conveyor belt
+            // character jumps every third frame so we multiply by 1.5
+            if (block.getMod(Layer.FRONT) == 0) {
+                deltaVelocityX += 1.5 * frontItem.getPower(); 
+            } else {
+                deltaVelocityX -= 1.5 * frontItem.getPower();
+            }
+
+            if (getVelocityY() < -0.001) {
+                deltaVelocityY -= getVelocityY();
+                groundHeight = 0.82f;
+                setVelocity(getVelocityX(), 0.0f);
+            }
+        }
+
+        if (Math.abs(deltaVelocityX) > 0.01 || Math.abs(deltaVelocityY) > 0.01) {
+            float yPosition  = groundHeight < 0
+              ? getY() + deltaTime * deltaVelocityY
+              : blockY + (hasDistance ? 2.7f : 1.8f) - groundHeight;
+
+            setPosition(getX() + deltaTime * deltaVelocityX, yPosition);
+
+            if (isPlayer()) ((Player) this).sendMessage(new PlayerPositionMessage(getX(), getY()));
+
+            zone.sendLocalMessage(new EntityPositionMessage(this), blockX, blockY);
         }
     }
     

--- a/gameserver/src/main/java/brainwine/gameserver/item/ItemUseType.java
+++ b/gameserver/src/main/java/brainwine/gameserver/item/ItemUseType.java
@@ -38,6 +38,7 @@ public enum ItemUseType {
     CHANGE(new ChangeInteraction()),
     FIELDABLE,
     FLY,
+    MOVE,
     MULTI,
     NOTE(new NoteInteraction()),
     PET,

--- a/gameserver/src/main/java/brainwine/gameserver/server/messages/PlayerPositionMessage.java
+++ b/gameserver/src/main/java/brainwine/gameserver/server/messages/PlayerPositionMessage.java
@@ -1,15 +1,15 @@
 package brainwine.gameserver.server.messages;
 
-import brainwine.gameserver.server.Message;
 import brainwine.gameserver.server.MessageInfo;
+import brainwine.gameserver.server.Message;
 
 @MessageInfo(id = 5)
 public class PlayerPositionMessage extends Message {
     
-    public int x;
-    public int y;
+    public float x;
+    public float y;
     
-    public PlayerPositionMessage(int x, int y) {
+    public PlayerPositionMessage(float x, float y) {
         this.x = x;
         this.y = y;
     }

--- a/gameserver/src/main/java/brainwine/gameserver/zone/Zone.java
+++ b/gameserver/src/main/java/brainwine/gameserver/zone/Zone.java
@@ -574,7 +574,37 @@ public class Zone {
         
         return false;
     }
-    
+
+    /**
+     * Find block with item occupying the block position that satisfies the predicate.
+     * Closer blocks are prioritized in row major order.
+     */
+    public Block findBlock(int x, int y, Layer layer, Predicate<Item> predicate) {
+        Block block;
+        Item item;
+
+        for (int i = 0; i >= -3; i--) {
+            for (int j = 0; j <= 2; j++) {
+                int x1 = x + i;
+                int y1 = y + j;
+
+                if (!areCoordinatesInBounds(x1, y1) || !isChunkLoaded(x1, y1)) {
+                    continue;
+                }
+
+                block = getBlock(x1, y1);
+                item = block.getItem(Layer.FRONT);
+
+                if (item.getBlockWidth() > Math.abs(i) && item.getBlockHeight() > Math.abs(j)
+                        && predicate.test(item)) {
+                    return block;
+                }
+            }
+        }
+
+        return null;
+    }
+
     public boolean isBlockOccupied(int x, int y, Layer layer) {
         if(!areCoordinatesInBounds(x, y)) {
             return false;


### PR DESCRIPTION
This is mainly for conveyor belt functionality, and is supposed to work for both players and NPCs.
- If a player or entity is standing on a front item with a `move: true` use, they will be pushed with power that is proportional to the power level of the item.

Problems
- [ ] I would like a general code review.
- [x] Maybe a player shouldn't be pushed if they have god mode.
- [x] Players get pushed into the conveyor belt for some reason.