### PR TITLE
Add min and max acidity to EntitySpawn

### DIFF
--- a/gameserver/src/main/java/brainwine/gameserver/zone/EntityManager.java
+++ b/gameserver/src/main/java/brainwine/gameserver/zone/EntityManager.java
@@ -70,19 +70,20 @@ public class EntityManager {
         }
     }
     
-    private static List<EntitySpawn> getEligibleEntitySpawns(Biome biome, String locale, double depth, Item baseItem) {
+    private static List<EntitySpawn> getEligibleEntitySpawns(Biome biome, String locale, double depth, double acidity, Item baseItem) {
         return spawns.entrySet().stream()
                 .filter(entry -> entry.getKey() == biome)
                 .map(Entry::getValue)
                 .flatMap(Collection::stream)
                 .filter(spawn -> locale.equalsIgnoreCase(spawn.getLocale())
                         && depth >= spawn.getMinDepth() && depth <= spawn.getMaxDepth()
+                        && acidity >= spawn.getMinAcidity() && acidity <= spawn.getMaxAcidity()
                         && ((!baseItem.hasId("base/maw") && !baseItem.hasId("base/pipe")) || spawn.getOrifice() == baseItem))
                 .collect(Collectors.toList());
     }
     
-    private static EntitySpawn getRandomEligibleEntitySpawn(Biome biome, String locale, double depth, Item baseItem) {
-        return new WeightedMap<>(getEligibleEntitySpawns(biome, locale, depth, baseItem), EntitySpawn::getFrequency).next();
+    private static EntitySpawn getRandomEligibleEntitySpawn(Biome biome, String locale, double depth, double acidity, Item baseItem) {
+        return new WeightedMap<>(getEligibleEntitySpawns(biome, locale, depth, acidity, baseItem), EntitySpawn::getFrequency).next();
     }
     
     public void tick(float deltaTime) {
@@ -132,7 +133,7 @@ public class EntityManager {
                 Block block = chunk.getBlock(x, y);
                 String locale = block.getBaseItem().isAir() ? "sky" : "cave";
                 EntitySpawn spawn = getRandomEligibleEntitySpawn(
-                        zone.getBiome(), locale, y / (double)zone.getHeight(), block.getBaseItem());
+                        zone.getBiome(), locale, y / (double)zone.getHeight(), zone.getAcidity(), block.getBaseItem());
                 
                 if(immediate) {
                     if(tryBustOrifice(x, y, Layer.BACK) || tryBustOrifice(x, y, Layer.FRONT)) {

--- a/gameserver/src/main/java/brainwine/gameserver/zone/EntitySpawn.java
+++ b/gameserver/src/main/java/brainwine/gameserver/zone/EntitySpawn.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import brainwine.gameserver.entity.EntityConfig;
 import brainwine.gameserver.item.Item;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.JsonMappingException;
 
 // TODO groups
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -21,6 +23,12 @@ public class EntitySpawn {
     
     @JsonProperty("max_depth")
     private double maxDepth = 1;
+
+    @JsonProperty("min_acidity")
+    private double minAcidity = 0.0;
+
+    @JsonProperty("max_acidity")
+    private double maxAcidity = 1.0;
     
     @JsonProperty("orifice")
     private Item orifice;
@@ -43,6 +51,14 @@ public class EntitySpawn {
     public double getMaxDepth() {
         return maxDepth;
     }
+
+    public double getMinAcidity() {
+        return minAcidity;
+    }
+
+    public double getMaxAcidity() {
+        return maxAcidity;
+    }
     
     public Item getOrifice() {
         return orifice;
@@ -51,4 +67,25 @@ public class EntitySpawn {
     public double getFrequency() {
         return frequency;
     }
+
+    private double normalizeAcidity(Object object) throws JsonMappingException {
+        if("purification threshold".equals(object)) {
+            return 0.05;
+        } else if(object instanceof Number) {
+            return ((Number) object).doubleValue();
+        }
+
+        throw new JsonMappingException("Unknown acidity value");
+    }
+
+    @JsonSetter
+    public void setMinAcidity(Object minAcidity) throws JsonMappingException {
+        this.minAcidity = normalizeAcidity(minAcidity);
+    }
+
+    @JsonSetter
+    public void setMaxAcidity(Object maxAcidity) throws JsonMappingException {
+        this.maxAcidity = normalizeAcidity(maxAcidity);
+    }
+
 }

--- a/gameserver/src/main/java/brainwine/gameserver/zone/EntitySpawn.java
+++ b/gameserver/src/main/java/brainwine/gameserver/zone/EntitySpawn.java
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import brainwine.gameserver.entity.EntityConfig;
 import brainwine.gameserver.item.Item;
-import com.fasterxml.jackson.annotation.JsonSetter;
-import com.fasterxml.jackson.databind.JsonMappingException;
 
 // TODO groups
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -66,26 +64,6 @@ public class EntitySpawn {
     
     public double getFrequency() {
         return frequency;
-    }
-
-    private double normalizeAcidity(Object object) throws JsonMappingException {
-        if("purification threshold".equals(object)) {
-            return 0.05;
-        } else if(object instanceof Number) {
-            return ((Number) object).doubleValue();
-        }
-
-        throw new JsonMappingException("Unknown acidity value");
-    }
-
-    @JsonSetter
-    public void setMinAcidity(Object minAcidity) throws JsonMappingException {
-        this.minAcidity = normalizeAcidity(minAcidity);
-    }
-
-    @JsonSetter
-    public void setMaxAcidity(Object maxAcidity) throws JsonMappingException {
-        this.maxAcidity = normalizeAcidity(maxAcidity);
     }
 
 }

--- a/gameserver/src/main/resources/spawning.json
+++ b/gameserver/src/main/resources/spawning.json
@@ -29,55 +29,55 @@
     {
       "entity": "creatures/bluejay",
       "locale": "sky",
-      "purification": 1.0,
+      "min_acidity": 0.05,
       "frequency": 3
     },
     {
       "entity": "creatures/cardinal",
       "locale": "sky",
-      "purification": 1.0,
+      "min_acidity": 0.05,
       "frequency": 1
     },
     {
       "entity": "creatures/seagull",
       "locale": "sky",
-      "purification": 1.0,
+      "min_acidity": 0.05,
       "frequency": 2
     },
     {
       "entity": "creatures/butterfly-monarch",
       "locale": "sky",
-      "purification": 1.0,
+      "min_acidity": 0.05,
       "frequency":23
     },
     {
       "entity": "creatures/papilio-ulysses",
       "locale": "sky",
-      "purification": 1.0,
+      "min_acidity": 0.05,
       "frequency": 0.5
     },
     {
       "entity": "creatures/butterfly-swallowtail",
       "locale": "sky",
-      "purification": 1.0,
+      "min_acidity": 0.05,
       "frequency": 1
     },
     {
       "entity": "creatures/butterfly-moth",
       "locale": "sky",
-      "purification": 1.0,
+      "min_acidity": 0.05,
       "frequency": 5
     },
     {
       "entity": "creatures/butterfly-owl",
       "locale": "sky",
-      "purification": 1.0,
+      "min_acidity": 0.05,
       "frequency": 0.1
     },
     {
       "entity": "creatures/butterfly-paper-kite",
       "locale": "sky",
-      "purification": 1.0,
+      "min_acidity": 0.05,
       "frequency": 0.01
     },
     {

--- a/gameserver/src/main/resources/spawning.json
+++ b/gameserver/src/main/resources/spawning.json
@@ -29,55 +29,55 @@
     {
       "entity": "creatures/bluejay",
       "locale": "sky",
-      "min_acidity": 0.05,
+      "max_acidity": 0.05,
       "frequency": 3
     },
     {
       "entity": "creatures/cardinal",
       "locale": "sky",
-      "min_acidity": 0.05,
+      "max_acidity": 0.05,
       "frequency": 1
     },
     {
       "entity": "creatures/seagull",
       "locale": "sky",
-      "min_acidity": 0.05,
+      "max_acidity": 0.05,
       "frequency": 2
     },
     {
       "entity": "creatures/butterfly-monarch",
       "locale": "sky",
-      "min_acidity": 0.05,
+      "max_acidity": 0.05,
       "frequency":23
     },
     {
       "entity": "creatures/papilio-ulysses",
       "locale": "sky",
-      "min_acidity": 0.05,
+      "max_acidity": 0.05,
       "frequency": 0.5
     },
     {
       "entity": "creatures/butterfly-swallowtail",
       "locale": "sky",
-      "min_acidity": 0.05,
+      "max_acidity": 0.05,
       "frequency": 1
     },
     {
       "entity": "creatures/butterfly-moth",
       "locale": "sky",
-      "min_acidity": 0.05,
+      "max_acidity": 0.05,
       "frequency": 5
     },
     {
       "entity": "creatures/butterfly-owl",
       "locale": "sky",
-      "min_acidity": 0.05,
+      "max_acidity": 0.05,
       "frequency": 0.1
     },
     {
       "entity": "creatures/butterfly-paper-kite",
       "locale": "sky",
-      "min_acidity": 0.05,
+      "max_acidity": 0.05,
       "frequency": 0.01
     },
     {


### PR DESCRIPTION
This is so that some entities can be kept from spawning in purified worlds.

Each of `min_acidity` and `max_acidity` can take two values: if a number is given (there is no bounds checking) the threshold is set to that value. If the string `"purification threshold"` is given, the value is set to the given threshold. Maybe this functionality, implemented in the `normalizeAcidity` method, can be moved to a separate location as an utility method that takes a  map of string aliases to numbers.