### PR TITLE
Add support for flower bulb saving

### DIFF
--- a/gameserver/src/main/java/brainwine/gameserver/item/ItemUseType.java
+++ b/gameserver/src/main/java/brainwine/gameserver/item/ItemUseType.java
@@ -34,6 +34,7 @@ public enum ItemUseType {
     CREATE_DIALOG(new DialogInteraction(true)),
     DESTROY,
     DIALOG(new DialogInteraction(false)),
+    DOWSING,
     EXPIATOR(new ExpiatorInteraction()),
     GECK(new GeckInteraction()),
     GUARD,

--- a/gameserver/src/main/java/brainwine/gameserver/item/MiningBonus.java
+++ b/gameserver/src/main/java/brainwine/gameserver/item/MiningBonus.java
@@ -12,9 +12,10 @@ public class MiningBonus {
     private double chance;
     private Skill skill;
     private ItemGroup tool;
-    private LazyItemGetter item;
+    private String item;
     private boolean doubleLoot;
     private String notification;
+    private ItemUseType accessory;
     
     @JsonCreator
     private MiningBonus() {}
@@ -30,9 +31,19 @@ public class MiningBonus {
     public ItemGroup getTool() {
         return tool;
     }
-    
-    public Item getItem() {
-        return item == null ? Item.AIR : item.get();
+
+    public ItemUseType getAccessory() {
+        return accessory;
+    }
+
+    public Item computeItem(Item minedItem) {
+        if(this.item == null) {
+            return Item.AIR;
+        }
+        if(this.item.startsWith("-") && minedItem != null) {
+            return ItemRegistry.getItem(minedItem.getId() + this.item);
+        }
+        return ItemRegistry.getItem(this.item);
     }
     
     @JsonProperty("double")

--- a/gameserver/src/main/java/brainwine/gameserver/item/MiningBonus.java
+++ b/gameserver/src/main/java/brainwine/gameserver/item/MiningBonus.java
@@ -12,10 +12,11 @@ public class MiningBonus {
     private double chance;
     private Skill skill;
     private ItemGroup tool;
+    private ItemUseType accessory;
+    private int mod = -1;
     private String item;
     private boolean doubleLoot;
     private String notification;
-    private ItemUseType accessory;
     
     @JsonCreator
     private MiningBonus() {}
@@ -34,6 +35,10 @@ public class MiningBonus {
 
     public ItemUseType getAccessory() {
         return accessory;
+    }
+
+    public int getMod() {
+        return mod;
     }
 
     public String getItem() {

--- a/gameserver/src/main/java/brainwine/gameserver/item/MiningBonus.java
+++ b/gameserver/src/main/java/brainwine/gameserver/item/MiningBonus.java
@@ -36,6 +36,10 @@ public class MiningBonus {
         return accessory;
     }
 
+    public String getItem() {
+        return item;
+    }
+
     public Item computeItem(Item minedItem) {
         if(this.item == null) {
             return Item.AIR;

--- a/gameserver/src/main/java/brainwine/gameserver/player/Player.java
+++ b/gameserver/src/main/java/brainwine/gameserver/player/Player.java
@@ -863,8 +863,10 @@ public class Player extends Entity implements CommandExecutor {
         if(heldItem.getGroup() != bonus.getTool()) {
             return 0.0;
         }
+
+        double accessoryBonus = getInventory().findAccessoryWithUse(ItemUseType.DOWSING).isAir() ? 1.0 : 2.0;
         
-        return bonus.getChance() * (getTotalSkillLevel(bonus.getSkill()) / (double)MAX_SKILL_LEVEL) * heldItem.getToolBonus();
+        return bonus.getChance() * (getTotalSkillLevel(bonus.getSkill()) / (double)MAX_SKILL_LEVEL) * heldItem.getToolBonus() * accessoryBonus;
     }
     
     /**

--- a/gameserver/src/main/java/brainwine/gameserver/player/Player.java
+++ b/gameserver/src/main/java/brainwine/gameserver/player/Player.java
@@ -866,7 +866,7 @@ public class Player extends Entity implements CommandExecutor {
 
         double accessoryBonus = getInventory().findAccessoryWithUse(ItemUseType.DOWSING).isAir() ? 1.0 : 2.0;
         
-        return bonus.getChance() * (getTotalSkillLevel(bonus.getSkill()) / (double)MAX_SKILL_LEVEL) * heldItem.getToolBonus() * accessoryBonus;
+        return bonus.getChance() * getNormalizedSkill(bonus.getSkill()) * heldItem.getToolBonus() * accessoryBonus;
     }
     
     /**

--- a/gameserver/src/main/java/brainwine/gameserver/server/requests/BlockMineRequest.java
+++ b/gameserver/src/main/java/brainwine/gameserver/server/requests/BlockMineRequest.java
@@ -195,8 +195,8 @@ public class BlockMineRequest extends PlayerRequest {
             MiningBonus bonus = item.getMiningBonus();
             
             if(Math.random() < player.getMiningBonusChance(bonus)) {
-                if(!bonus.getItem().isAir()) {
-                    inventoryItem = bonus.getItem();
+                if(!bonus.computeItem(item).isAir()) {
+                    inventoryItem = bonus.computeItem(item);
                 }
                 
                 if(bonus.isDoubleLoot()) {

--- a/gameserver/src/main/java/brainwine/gameserver/server/requests/BlockMineRequest.java
+++ b/gameserver/src/main/java/brainwine/gameserver/server/requests/BlockMineRequest.java
@@ -188,13 +188,10 @@ public class BlockMineRequest extends PlayerRequest {
             player.getStatistics().trackItemScavenged(item);
         }
         
-        zone.updateBlock(x, y, layer, 0, 0, player);
-        
         // Apply mining bonus if there is one
         if(item.hasMiningBonus()) {
             MiningBonus bonus = item.getMiningBonus();
-            
-            if(Math.random() < player.getMiningBonusChance(bonus)) {
+            if(Math.random() < player.getMiningBonusChance(bonus) && bonus.getMod() <= block.getMod(layer)) {
                 if(!bonus.computeItem(item).isAir()) {
                     inventoryItem = bonus.computeItem(item);
                 }
@@ -206,6 +203,8 @@ public class BlockMineRequest extends PlayerRequest {
                 player.notify(bonus.getNotification(), NotificationType.FANCY_EMOTE);
             }
         }
+
+        zone.updateBlock(x, y, layer, 0, 0, player);
         
         if(!inventoryItem.isAir()) {
             player.getInventory().addItem(inventoryItem, quantity, true);


### PR DESCRIPTION
Flower mining bonus uses "-bulb" as the item name to reduce the amount of configuration lines needed. BrainWine previously couldn't handle this.

I also changed the miningBonusChance code a bit to match the original server more closely,