### PR TITLE
Make target teleporters only check for player-owned protector fields.

### DIFF
--- a/gameserver/src/main/java/brainwine/gameserver/item/interactions/TargetTeleportInteraction.java
+++ b/gameserver/src/main/java/brainwine/gameserver/item/interactions/TargetTeleportInteraction.java
@@ -11,8 +11,6 @@ import brainwine.gameserver.zone.Biome;
 import brainwine.gameserver.zone.MetaBlock;
 import brainwine.gameserver.zone.Zone;
 
-import java.util.List;
-
 public class TargetTeleportInteraction implements ItemInteraction {
     
     @Override

--- a/gameserver/src/main/java/brainwine/gameserver/item/interactions/TargetTeleportInteraction.java
+++ b/gameserver/src/main/java/brainwine/gameserver/item/interactions/TargetTeleportInteraction.java
@@ -11,6 +11,8 @@ import brainwine.gameserver.zone.Biome;
 import brainwine.gameserver.zone.MetaBlock;
 import brainwine.gameserver.zone.Zone;
 
+import java.util.List;
+
 public class TargetTeleportInteraction implements ItemInteraction {
     
     @Override
@@ -75,12 +77,16 @@ public class TargetTeleportInteraction implements ItemInteraction {
             player.notify("That area hasn't been explored yet.");
             return;
         }
+
+        List<MetaBlock> protectors = zone.getMetaBlocks(
+                m -> m.hasOwner()
+                               && m.getItem().getId().startsWith("mechanical/dish"));
         
         // Check area protection
-        if(!player.isGodMode() && targetZone.isBlockProtected(targetX, targetY, player)) {
+        if(!player.isGodMode() && targetZone.isBlockProtectedByField(targetX, targetY, player, protectors)) {
             Player owner = metaBlock.getOwner();
             int setting = metaBlock.getIntProperty("pt");
-            boolean ownerCanEdit = !targetZone.isBlockProtected(targetX, targetY, owner);
+            boolean ownerCanEdit = !targetZone.isBlockProtectedByField(targetX, targetY, owner, protectors);
             
             // Check protection entry setting
             if(owner == null || !ownerCanEdit || setting == 0 || (setting == 1 && !owner.isFollowing(player))) {

--- a/gameserver/src/main/java/brainwine/gameserver/item/interactions/TargetTeleportInteraction.java
+++ b/gameserver/src/main/java/brainwine/gameserver/item/interactions/TargetTeleportInteraction.java
@@ -78,15 +78,11 @@ public class TargetTeleportInteraction implements ItemInteraction {
             return;
         }
 
-        List<MetaBlock> protectors = zone.getMetaBlocks(
-                m -> m.hasOwner()
-                               && m.getItem().getId().startsWith("mechanical/dish"));
-        
         // Check area protection
-        if(!player.isGodMode() && targetZone.isBlockProtectedByField(targetX, targetY, player, protectors)) {
+        if(!player.isGodMode() && targetZone.isBlockProtectedByField(targetX, targetY, player)) {
             Player owner = metaBlock.getOwner();
             int setting = metaBlock.getIntProperty("pt");
-            boolean ownerCanEdit = !targetZone.isBlockProtectedByField(targetX, targetY, owner, protectors);
+            boolean ownerCanEdit = !targetZone.isBlockProtectedByField(targetX, targetY, owner);
             
             // Check protection entry setting
             if(owner == null || !ownerCanEdit || setting == 0 || (setting == 1 && !owner.isFollowing(player))) {

--- a/gameserver/src/main/java/brainwine/gameserver/zone/Zone.java
+++ b/gameserver/src/main/java/brainwine/gameserver/zone/Zone.java
@@ -655,6 +655,10 @@ public class Zone {
             return true;
         }
         
+        return isBlockProtectedByField(x, y, player, fieldBlocks);
+    }
+
+    public boolean isBlockProtectedByField(int x, int y, Player player, Collection<MetaBlock> fieldBlocks) {
         // Check field blocks
         for(MetaBlock fieldBlock : fieldBlocks) {
             Item item = fieldBlock.getItem();
@@ -675,7 +679,7 @@ public class Zone {
                 }
             }
         }
-        
+
         return false;
     }
     

--- a/gameserver/src/main/java/brainwine/gameserver/zone/Zone.java
+++ b/gameserver/src/main/java/brainwine/gameserver/zone/Zone.java
@@ -658,6 +658,10 @@ public class Zone {
         return isBlockProtectedByField(x, y, player, fieldBlocks);
     }
 
+    public boolean isBlockProtectedByField(int x, int y, Player player) {
+        return isBlockProtectedByField(x, y, player, fieldBlocks.values());
+    }
+
     public boolean isBlockProtectedByField(int x, int y, Player player, Collection<MetaBlock> fieldBlocks) {
         // Check field blocks
         for(MetaBlock fieldBlock : fieldBlocks) {


### PR DESCRIPTION
Very simple fix.

Maybe protectors can be indexed in the Zone.class just like for example global metablocks, but I find it unnecessary.