### PR TITLE
Guard against followees and followers who changed their name

### DIFF
--- a/gameserver/src/main/java/brainwine/gameserver/server/requests/DialogRequest.java
+++ b/gameserver/src/main/java/brainwine/gameserver/server/requests/DialogRequest.java
@@ -61,6 +61,11 @@ public class DialogRequest extends PlayerRequest {
         
         // Create player info dialog
         Player subject = GameServer.getInstance().getPlayerManager().getPlayer((String)input[0]);
+        if(subject == null) {
+            player.showDialog(DialogHelper.messageDialog("Player not found!"));
+            return;
+        }
+
         Dialog dialog = new Dialog().setTitle(subject.getName());
         
         // Online status section


### PR DESCRIPTION
If a player who is visible on a follower/followee list changes their name before the viewing player could click their name, it would not be able to find the player by name, and the server would crash. This fix mitigates this by failing early on an unknown name.