### PR TITLE
Always validate place mod sent from the client

### DIFF
--- a/gameserver/src/main/java/brainwine/gameserver/item/Item.java
+++ b/gameserver/src/main/java/brainwine/gameserver/item/Item.java
@@ -57,6 +57,9 @@ public class Item {
     
     @JsonProperty("mod")
     private ModType mod = ModType.NONE;
+
+    @JsonProperty("place mod")
+    private int placeMod;
     
     @JsonProperty("meta")
     private MetaType meta = MetaType.NONE;
@@ -328,6 +331,10 @@ public class Item {
     
     public ModType getMod() {
         return mod;
+    }
+
+    public int getPlaceMod() {
+        return placeMod;
     }
     
     public boolean hasMeta() {

--- a/gameserver/src/main/java/brainwine/gameserver/server/requests/BlockPlaceRequest.java
+++ b/gameserver/src/main/java/brainwine/gameserver/server/requests/BlockPlaceRequest.java
@@ -109,11 +109,17 @@ public class BlockPlaceRequest extends PlayerRequest {
             fail(player, "Dish will overlap another protector.");
             return;
         }
-        
+
         if(layer == Layer.LIQUID) {
             mod = 5;
-        } else if(item.getMod() == ModType.ROTATION && !item.isMirrorable()) {
-            mod = findRotationMod(zone, x, y, item.getBlockWidth(), item.getBlockHeight());
+        } else if(item.getMod() == ModType.ROTATION) {
+            if(item.isMirrorable()) {
+                mod = mod == 4 ? 4 : 0;
+            } else {
+                mod = findRotationMod(zone, x, y, item.getBlockWidth(), item.getBlockHeight());
+            }
+        } else {
+            mod = item.getPlaceMod();
         }
         
         zone.updateBlock(x, y, layer, item, mod, player);


### PR DESCRIPTION
Players could place items of mod: stack with an arbitrary block mod, enabling them to duplicate rubble minerals and bone piles. This patches it by running the place mod logic again on the server.